### PR TITLE
Add client/dump/restore functionality

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM quay.io/aptible/alpine
 
 ENV DATA_DIRECTORY /var/db
 
-RUN apk-install redis=2.8.17-r0
+# rdbtools is used for importing an RDB dump remotely.
+RUN apk-install redis=2.8.17-r0 py-pip=1.5.6-r2 && pip install rdbtools
 ADD templates/redis.conf /etc/redis.conf
 
 # Integration tests
@@ -14,8 +15,8 @@ EXPOSE 6379
 
 ENV CONFIG_DIRECTORY /etc/redis
 VOLUME ["$CONFIG_DIRECTORY"]
+EXPOSE 6379
 
 ADD run-database.sh /usr/bin/
+ADD utilities.sh /usr/bin/
 ENTRYPOINT ["run-database.sh"]
-
-EXPOSE 6379

--- a/run-database.sh
+++ b/run-database.sh
@@ -1,10 +1,40 @@
 #!/bin/bash
 
+. /usr/bin/utilities.sh
 ARGUMENT_FILE="$CONFIG_DIRECTORY"/arguments
+DUMP_FILENAME="/tmp/dump.rdb"
+
+start_server()
+{
+  touch $ARGUMENT_FILE # don't crash and burn if initialize wasn't called.
+  redis-server /etc/redis.conf --dir "$DATA_DIRECTORY" $(cat "$ARGUMENT_FILE")
+}
+
 if [[ "$1" == "--initialize" ]]; then
   echo "--requirepass "$PASSPHRASE"" > "$ARGUMENT_FILE"
-  exit
-fi
 
-touch $ARGUMENT_FILE # don't crash and burn if initialize wasn't called.
-redis-server /etc/redis.conf --dir "$DATA_DIRECTORY" $(cat "$ARGUMENT_FILE")
+elif [[ "$1" == "--client" ]]; then
+  [ -z "$2" ] && echo "docker run -it aptible/redis --client redis://..." && exit
+  parse_url "$2"
+  redis-cli -h "$host" -p "${port:-6379}" -a "$password"
+
+elif [[ "$1" == "--dump" ]]; then
+  [ -z "$2" ] && echo "docker run -i aptible/redis --dump redis://... > dump.rdb" && exit
+  parse_url "$2"
+  redis-cli -h "$host" -p "${port:-6379}" -a "$password" --rdb "$DUMP_FILENAME"
+  cat "$DUMP_FILENAME"
+
+elif [[ "$1" == "--restore" ]]; then
+  [ -z "$2" ] && echo "docker run -i aptible/redis --restore redis://... < dump.rdb" && exit
+  parse_url "$2"
+  cat > "$DUMP_FILENAME"
+  rdb --command protocol "$DUMP_FILENAME" | redis-cli -h "$host" -p "${port:-6379}" -a "$password" --pipe
+
+elif [[ "$1" == "--readonly" ]]; then
+  echo "This image does not support read-only mode. Starting database normally."
+  start_server
+
+else
+  start_server
+
+fi

--- a/utilities.sh
+++ b/utilities.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+parse_url()
+{
+  # cf http://stackoverflow.com/a/17287984
+  protocol="$(echo "$1" | grep :// | sed -e's,^\(.*://\).*,\1,g')"
+  # remove the protocol
+  url=$(echo $1 | sed -e s,$protocol,,g)
+  # extract the user and password (if any)
+  user_and_password="$(echo $url | grep @ | cut -d@ -f1)"
+  password="$(echo $user_and_password | grep : | cut -d: -f2)"
+  if [ -n "$password" ]; then
+    user="$(echo $user_and_password | grep : | cut -d: -f1)"
+  else
+    user="$user_and_password"
+  fi
+
+  # extract the host
+  host_and_port="$(echo $url | sed -e s,$user_and_password@,,g | cut -d/ -f1)"
+  port="$(echo $host_and_port | grep : | cut -d: -f2)"
+  if [ -n "$port" ]; then
+    host="$(echo $host_and_port | grep : | cut -d: -f1)"
+  else
+    host="$host_and_port"
+  fi
+
+  database="$(echo $url | grep / | cut -d/ -f2-)"
+}


### PR DESCRIPTION
Notes:

* `redis-cli` has an option for dumping a redis rdb file from a remote server, but not for importing. I've added the `rdbtools` python package for importing the rdb file.
* I haven't found a way to put the redis server in readonly mode.