### PR TITLE
Redis 2.8.24

### DIFF
--- a/2.8/Dockerfile
+++ b/2.8/Dockerfile
@@ -10,19 +10,19 @@ RUN /install-redis.sh
 RUN apk-install py-pip && pip install rdbtools
 ADD templates/redis.conf /etc/redis.conf
 
+ADD run-database.sh /usr/bin/
+ADD utilities.sh /usr/bin/
+
+ENV DATA_DIRECTORY /var/db
+VOLUME ["$DATA_DIRECTORY"]
+
+ENV CONFIG_DIRECTORY /etc/redis
+VOLUME ["$CONFIG_DIRECTORY"]
+
 # Integration tests
 ADD test /tmp/test
 RUN bats /tmp/test
 
-ENV DATA_DIRECTORY /var/db
-
-VOLUME ["$DATA_DIRECTORY"]
 EXPOSE 6379
 
-ENV CONFIG_DIRECTORY /etc/redis
-VOLUME ["$CONFIG_DIRECTORY"]
-EXPOSE 6379
-
-ADD run-database.sh /usr/bin/
-ADD utilities.sh /usr/bin/
 ENTRYPOINT ["run-database.sh"]

--- a/2.8/Dockerfile
+++ b/2.8/Dockerfile
@@ -7,7 +7,7 @@ ADD ./install-redis.sh /install-redis.sh
 RUN /install-redis.sh
 
 # rdbtools is used for importing an RDB dump remotely.
-RUN apk-install py-pip && pip install rdbtools
+RUN apk-install py-pip coreutils && pip install rdbtools
 ADD templates/redis.conf /etc/redis.conf
 
 ADD run-database.sh /usr/bin/

--- a/2.8/Dockerfile
+++ b/2.8/Dockerfile
@@ -1,14 +1,20 @@
 FROM quay.io/aptible/alpine
 
-ENV DATA_DIRECTORY /var/db
+ENV REDIS_VERSION 2.8.24
+ENV REDIS_SHA1SUM 636efa8b522dfbf7f3dba372237492c11181f8e0
+
+ADD ./install-redis.sh /install-redis.sh
+RUN /install-redis.sh
 
 # rdbtools is used for importing an RDB dump remotely.
-RUN apk-install redis=2.8.21-r0 py-pip=1.5.6-r2 && pip install rdbtools
+RUN apk-install py-pip && pip install rdbtools
 ADD templates/redis.conf /etc/redis.conf
 
 # Integration tests
 ADD test /tmp/test
 RUN bats /tmp/test
+
+ENV DATA_DIRECTORY /var/db
 
 VOLUME ["$DATA_DIRECTORY"]
 EXPOSE 6379

--- a/2.8/install-redis.sh
+++ b/2.8/install-redis.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REDIS_NAME="redis-${REDIS_VERSION}"
+REDIS_ARCHIVE="${REDIS_NAME}.tar.gz"
+REDIS_URL="http://download.redis.io/releases/${REDIS_ARCHIVE}"
+REDIS_BUILD_DEPS=(alpine-sdk linux-headers)
+
+apk-install "${REDIS_BUILD_DEPS[@]}"
+
+redis_build_dir="/tmp/redis-build"
+mkdir "${redis_build_dir}"
+pushd "${redis_build_dir}"
+
+wget "${REDIS_URL}"
+echo "${REDIS_SHA1SUM}  ${REDIS_ARCHIVE}" | sha1sum -c -
+tar -xf "${REDIS_ARCHIVE}"
+pushd "${REDIS_NAME}"
+
+# Get the Alpine Linux no backtrace patch. Backtrace isn't available in Muslc,
+# but Redis 2.8.x doesn't check for Glibc before enabling it.
+NO_BACKTRACE_PATCH="redis-no-backtrace.patch"
+wget "https://raw.githubusercontent.com/alpinelinux/aports/115f0915bb5bb7c9c36b43c7fbfe0dd11435580c/main/redis/${NO_BACKTRACE_PATCH}"
+
+patch -p1 -i "./${NO_BACKTRACE_PATCH}"
+
+make all PREFIX=/usr/local MALLOC=libc
+make install
+
+popd
+popd
+
+rm -rf "${redis_build_dir}"
+apk del "${REDIS_BUILD_DEPS[@]}"

--- a/2.8/run-database.sh
+++ b/2.8/run-database.sh
@@ -20,7 +20,9 @@ if [[ "$1" == "--initialize" ]]; then
 elif [[ "$1" == "--client" ]]; then
   [ -z "$2" ] && echo "docker run -it aptible/redis --client redis://..." && exit
   parse_url "$2"
-  redis-cli -h "$host" -p "${port:-6379}" -a "$password"
+  shift
+  shift
+  redis-cli -h "$host" -p "${port:-6379}" -a "$password" "$@"
 
 elif [[ "$1" == "--dump" ]]; then
   [ -z "$2" ] && echo "docker run -i aptible/redis --dump redis://... > dump.rdb" && exit

--- a/2.8/test/redis.bats
+++ b/2.8/test/redis.bats
@@ -1,5 +1,43 @@
 #!/usr/bin/env bats
 
+setup() {
+  export OLD_DATA_DIRECTORY="$DATA_DIRECTORY"
+  export OLD_CONFIG_DIRECTORY="$CONFIG_DIRECTORY"
+  export DATA_DIRECTORY="/tmp/datadir"
+  export CONFIG_DIRECTORY="/tmp/configdir"
+  export DATABASE_PASSWORD="password12345"
+  export DATABASE_URL="redis://:$DATABASE_PASSWORD@localhost/db"
+  rm -rf "$DATA_DIRECTORY"
+  mkdir -p "$DATA_DIRECTORY"
+  rm -rf "$CONFIG_DIRECTORY"
+  mkdir -p "$CONFIG_DIRECTORY"
+}
+
+
+teardown() {
+  export DATA_DIRECTORY="$OLD_DATA_DIRECTORY"
+  export CONFIG_DIRECTORY="$OLD_CONFIG_DIRECTORY"
+  unset OLD_DATA_DIRECTORY
+  unset OLD_CONFIG_DIRECTORY
+  unset DATABASE_URL
+  stop_redis
+}
+
+
+start_redis () {
+  PASSPHRASE="$DATABASE_PASSWORD" run-database.sh --initialize
+  run-database.sh > "$BATS_TEST_DIRNAME/redis.log" &
+  timeout -t 4 sh -c "while  ! grep 'ready to accept connections' '$BATS_TEST_DIRNAME/redis.log' ; do sleep 0.1; done"
+}
+
+
+stop_redis () {
+  PID=$(pgrep redis-server) || return 0
+  pkill redis-server
+  while [ -n "$PID" ] && [ -e /proc/$PID ]; do sleep 0.1; done
+}
+
+
 @test "It should install Redis " {
   run redis-server --version
   [[ "$output" =~ "2.8.24"  ]]
@@ -7,4 +45,36 @@
 
 @test "It should install Redis to /usr/local/bin/redis-server" {
   test -x /usr/local/bin/redis-server
+}
+
+@test "It should start Redis" {
+  start_redis
+  run-database.sh --client "$DATABASE_URL" SET test_key test_value
+  run run-database.sh --client "$DATABASE_URL" GET test_key
+  [ "$status" -eq "0" ]
+  [[ "$output" = "test_value" ]]
+}
+
+@test "It should backup and restore" {
+  # Load a key
+  start_redis
+  run-database.sh --client "$DATABASE_URL" SET test_key test_value
+  run-database.sh --dump "$DATABASE_URL" > redis.dump
+  stop_redis
+
+  # Drop ALL the data!!!
+  rm -rf "$DATA_DIRECTORY"
+  mkdir "$DATA_DIRECTORY"
+
+  # Restart. Data should be gone.
+  start_redis
+  run run-database.sh --client "$DATABASE_URL" GET test_key
+  [ "$status" -eq "0" ]
+  [[ "$output" = "" ]]
+
+  # Restore. Data should be back.
+  run-database.sh --restore "$DATABASE_URL" < redis.dump
+  run run-database.sh --client "$DATABASE_URL" GET test_key
+  [ "$status" -eq "0" ]
+  [[ "$output" = "test_value" ]]
 }

--- a/2.8/test/redis.bats
+++ b/2.8/test/redis.bats
@@ -2,9 +2,9 @@
 
 @test "It should install Redis " {
   run redis-server --version
-  [[ "$output" =~ "2.8.21"  ]]
+  [[ "$output" =~ "2.8.24"  ]]
 }
 
-@test "It should install Redis to /usr/bin/redis-server" {
-  test -x /usr/bin/redis-server
+@test "It should install Redis to /usr/local/bin/redis-server" {
+  test -x /usr/local/bin/redis-server
 }

--- a/2.8/test/redis.bats
+++ b/2.8/test/redis.bats
@@ -27,7 +27,7 @@ teardown() {
 start_redis () {
   PASSPHRASE="$DATABASE_PASSWORD" run-database.sh --initialize
   run-database.sh > "$BATS_TEST_DIRNAME/redis.log" &
-  timeout -t 4 sh -c "while  ! grep 'ready to accept connections' '$BATS_TEST_DIRNAME/redis.log' ; do sleep 0.1; done"
+  timeout 4 sh -c "while  ! grep 'ready to accept connections' '$BATS_TEST_DIRNAME/redis.log' ; do sleep 0.1; done"
 }
 
 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ In addition to the standard Aptible database ENV variables, which may be specifi
 
 ## Available Tags
 
-* `latest`: Currently Redis 2.8.21
-* `2.8`: Redis 2.8.21
+* `latest`: Currently Redis 2.8.24
+* `2.8`: Redis 2.8.24
 
 ## Tests
 


### PR DESCRIPTION
- Upgraded Redis to 2.8.24 (compiling from source since 2.8.x is no longer in Alpine).
- The `--client` command now forwards whatever is after the database URL to the client, which allows for non-interactive testing...
- ... which was used to add tests

I've removed the version constraint on pip (because pip was updated as well). Arguably any version of pip should be able to install rdbtools. Let me know if you'd rather we don't do that.

Cheers,

---

cc @aaw @fancyremarker 