### PR TITLE
Switch from libc to jemalloc memory allocator

### DIFF
--- a/bin/install-redis.sh
+++ b/bin/install-redis.sh
@@ -28,7 +28,7 @@ if [[ "$REDIS_VERSION" =~ ^2.8.[0-9]+$ ]]; then
   patch -p1 -i "./${NO_BACKTRACE_PATCH}"
 fi
 
-make all PREFIX=/usr/local MALLOC=libc
+make all PREFIX=/usr/local MALLOC=jemalloc
 make install
 
 popd


### PR DESCRIPTION
In practice, jemalloc can perform much better than libc in terms of fragmentation; it's also the default MALLOC for Redis under Linux.