### PR TITLE
Add support for Append only persistence

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,16 @@ env:
   matrix:
     - TAG=2.8
     - TAG=2.8-nordb
+    - TAG=2.8-aof
     - TAG=3.0
     - TAG=3.0-nordb
+    - TAG=3.0-aof
     - TAG=3.2
     - TAG=3.2-nordb
+    - TAG=3.2-aof
     - TAG=4.0
     - TAG=4.0-nordb
+    - TAG=4.0-aof
 
 script:
   - make build

--- a/2.8-aof/config.mk
+++ b/2.8-aof/config.mk
@@ -1,0 +1,4 @@
+export REDIS_VERSION = 2.8.24
+export REDIS_SHA1SUM = 636efa8b522dfbf7f3dba372237492c11181f8e0
+
+export REDIS_AOF = 1

--- a/2.8-aof/test/redis-2.8.bats
+++ b/2.8-aof/test/redis-2.8.bats
@@ -1,0 +1,1 @@
+../../test/shared/redis-2.8.bats

--- a/2.8-aof/test/redis-persistence.bats
+++ b/2.8-aof/test/redis-persistence.bats
@@ -1,0 +1,1 @@
+../../test/shared/redis-persistence.bats

--- a/2.8/test/redis-persistence.bats
+++ b/2.8/test/redis-persistence.bats
@@ -1,0 +1,1 @@
+../../test/shared/redis-persistence.bats

--- a/2.8/test/redis-rdb.bats
+++ b/2.8/test/redis-rdb.bats
@@ -1,1 +1,0 @@
-../../test/shared/redis-rdb.bats

--- a/3.0-aof/config.mk
+++ b/3.0-aof/config.mk
@@ -1,0 +1,4 @@
+export REDIS_VERSION = 3.0.7
+export REDIS_SHA1SUM = e56b4b7e033ae8dbf311f9191cf6fdf3ae974d1c
+
+export REDIS_AOF = 1

--- a/3.0-aof/test/redis-3.0.bats
+++ b/3.0-aof/test/redis-3.0.bats
@@ -1,0 +1,1 @@
+../../test/shared/redis-3.0.bats

--- a/3.0-aof/test/redis-persistence.bats
+++ b/3.0-aof/test/redis-persistence.bats
@@ -1,0 +1,1 @@
+../../test/shared/redis-persistence.bats

--- a/3.0/test/redis-persistence.bats
+++ b/3.0/test/redis-persistence.bats
@@ -1,0 +1,1 @@
+../../test/shared/redis-persistence.bats

--- a/3.0/test/redis-rdb.bats
+++ b/3.0/test/redis-rdb.bats
@@ -1,1 +1,0 @@
-../../test/shared/redis-rdb.bats

--- a/3.2-aof/config.mk
+++ b/3.2-aof/config.mk
@@ -1,0 +1,4 @@
+export REDIS_VERSION = 3.2.12
+export REDIS_SHA1SUM = 6dafafd1addd84c4a9e830bc0b1ac8bab8b7b455
+
+export REDIS_AOF = 1

--- a/3.2-aof/test/redis-3.2.bats
+++ b/3.2-aof/test/redis-3.2.bats
@@ -1,0 +1,1 @@
+../../test/shared/redis-3.2.bats

--- a/3.2-aof/test/redis-persistence.bats
+++ b/3.2-aof/test/redis-persistence.bats
@@ -1,0 +1,1 @@
+../../test/shared/redis-persistence.bats

--- a/3.2/test/redis-persistence.bats
+++ b/3.2/test/redis-persistence.bats
@@ -1,0 +1,1 @@
+../../test/shared/redis-persistence.bats

--- a/3.2/test/redis-rdb.bats
+++ b/3.2/test/redis-rdb.bats
@@ -1,1 +1,0 @@
-../../test/shared/redis-rdb.bats

--- a/4.0-aof/config.mk
+++ b/4.0-aof/config.mk
@@ -1,0 +1,4 @@
+export REDIS_VERSION = 4.0.11
+export REDIS_SHA1SUM = a13ccf0f7051f82dc1c979bd94f0b9a9ba039122
+
+export REDIS_AOF = 1

--- a/4.0-aof/test/redis-4.0.bats
+++ b/4.0-aof/test/redis-4.0.bats
@@ -1,0 +1,4 @@
+@test "It should install Redis 4.0.11" {
+  run redis-server --version
+  [[ "$output" =~ "4.0.11"  ]]
+}

--- a/4.0-aof/test/redis-persistence.bats
+++ b/4.0-aof/test/redis-persistence.bats
@@ -1,0 +1,1 @@
+../../test/shared/redis-persistence.bats

--- a/4.0/test/redis-persistence.bats
+++ b/4.0/test/redis-persistence.bats
@@ -1,0 +1,1 @@
+../../test/shared/redis-persistence.bats

--- a/4.0/test/redis-rdb.bats
+++ b/4.0/test/redis-rdb.bats
@@ -1,1 +1,0 @@
-../../test/shared/redis-rdb.bats

--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -45,6 +45,12 @@ ENV CA_CERTS=/etc/ssl
 ENV REDIS_NORDB <%= ENV.fetch 'REDIS_NORDB' %>
 <% end %>
 
+<% if ENV['REDIS_AOF'] %>
+ENV REDIS_AOF <%= ENV.fetch 'REDIS_AOF' %>
+<% end %>
+
+ENV TAG <%= ENV.fetch 'TAG' %>
+
 # Volumes: Aptible will automatically mount these on an EBS device
 VOLUME ["$DATA_DIRECTORY"]
 VOLUME ["$CONFIG_DIRECTORY"]

--- a/README.md
+++ b/README.md
@@ -27,11 +27,19 @@ In addition to the standard Aptible database ENV variables, which may be specifi
 
 ## Available Tags
 
-* `latest`: Currently Redis 4.0
-* `4.0`: Redis 4.0.11
-* `3.2`: Redis 3.2.12
-* `3.0`: Redis 3.0.7 [EOL](https://redis.io/topics/releases)
-* `2.8`: Redis 2.8.24 [EOL](https://redis.io/topics/releases)
+* `latest`: Currently Redis 4.0-aof
+* `4.0`: Redis 4.0.11 w/ RDB persistence
+* `4.0-aof`: AOF+RDB persistence
+* `4.0-nordb: no persistennce
+* `3.2`: Redis 3.2.12 w/ RDB persistence
+* `3.2-aof`: AOF+RDB persistence
+* `3.2-nordb: no persistennce
+* `3.0`: Redis 3.0.7 w/ RDB persistence [EOL](https://redis.io/topics/releases)
+* `3.0-aof`: AOF+RDB persistence
+* `3.0-nordb: no persistennce
+* `2.8`: Redis 2.8.24 w/ RDB persistence [EOL](https://redis.io/topics/releases)
+* `2.8-aof`: AOF+RDB persistence
+* `2.8-nordb: no persistennce
 
 ## Tests
 

--- a/bin/run-database.sh
+++ b/bin/run-database.sh
@@ -166,6 +166,10 @@ elif [[ "$1" == "--initialize" ]]; then
     echo 'save ""' >> "$CONFIG_EXTRA_FILE"
   fi
 
+  if [[ -n "${REDIS_AOF:-}" ]]; then
+    echo 'appendonly yes' >> "$CONFIG_EXTRA_FILE"
+  fi
+
 elif [[ "$1" == "--initialize-from" ]]; then
   [ -z "$2" ] && echo "docker run -i aptible/redis --initialize-from redis://... rediss://..." && exit
   shift

--- a/latest.mk
+++ b/latest.mk
@@ -1,1 +1,1 @@
-LATEST_TAG = 4.0
+LATEST_TAG = 4.0-aof

--- a/test/shared/redis-persistence.bats
+++ b/test/shared/redis-persistence.bats
@@ -15,7 +15,17 @@ teardown() {
   run-database.sh --client "$REDIS_DATABASE_URL" SET test_key test_value
 
   stop_redis
+
+  [[ -f "${DATA_DIRECTORY}/dump.rdb" ]]
+
+  if [[ "$TAG" =~ .*-aof ]]; then
+    [[ -f "${DATA_DIRECTORY}/appendonly.aof" ]]
+  else
+    [[ ! -f "${DATA_DIRECTORY}/appendonly.aof" ]]
+  fi
+
   start_redis
 
   run-database.sh --client "$REDIS_DATABASE_URL" GET test_key | grep -q test_value
+
 }


### PR DESCRIPTION
This adds a `$VERSION-aof` tag, which enables Append Only File persistence, in _addition_ to RDB persistence.  The benefit here is that AOF will sync data to disk much more frequently, by default every 1 second, 

This frequency can be changed in $CONFIG_EXTRA_FILE,  Redis supports three different modes for the `appendfsync`

* no: don't fsync, just let the OS flush the data when it wants. Faster.
* always: fsync after every write to the append only log. Slow, Safest.
* everysec: fsync only one time every second. Compromise.

The current image tags and Enclave descriptions are:

| Tag  | description | default | visible | indexable |
| - | - | - | - | - |
| 4.0 | Redis 4.0 | true | true | true |
| 4.0-nordb | Redis 4.0 - NO PERSISTENCE | false | false | true |

We intend to make this the default Redis database type, and update image descriptions (for all versions) as follows:

| Tag  | description | default | visible | indexable |
| - | - | - | - | -| 
| 4.0 | Redis 4.0 - RDB-Only Persistence | false | false | true|
| 4.0-nordb | Redis 4.0 - NO PERSISTENCE | false | false | true |
| 4.0-aof | REDIS 4.0 | true | true  | true |

In case AOF corruption causes a database not to start (recovery throttled warning), it may be an AOF corruption issue. The Redis documentation recomends:

```What should I do if my AOF gets corrupted?
It is possible that the server crashes while writing the AOF file (this still should never lead to inconsistencies), corrupting the file in a way that is no longer loadable by Redis. When this happens you can fix this problem using the following procedure:

* Make a backup copy of your AOF file.
* Fix the original file using the redis-check-aof tool that ships with Redis:
    $ redis-check-aof --fix
* Optionally use diff -u to check what is the difference between two files.
* Restart the server with the fixed file.
```


I've simulated a possible corruption here for reference, the final `diff` I would recommend providing to the customer to say "this AOF record was corrupted and needed to be truncated(removed) to start your server, perhaps you can fix or account for it".

https://gist.github.com/UserNotFound/c8534eefb614e53dd4675622e6fc1e28
