### PR TITLE
Add support for Redis ACLs

### DIFF
--- a/6.0-aof/test/acl-tls.bats
+++ b/6.0-aof/test/acl-tls.bats
@@ -1,0 +1,1 @@
+../../test/shared/acl-tls.bats

--- a/6.0-aof/test/integrated-tls.bats
+++ b/6.0-aof/test/integrated-tls.bats
@@ -1,1 +1,0 @@
-../../test/shared/integrated-tls.bats

--- a/6.0-nordb/test/acl-tls.bats
+++ b/6.0-nordb/test/acl-tls.bats
@@ -1,0 +1,1 @@
+../../test/shared/acl-tls.bats

--- a/6.0-nordb/test/integrated-tls.bats
+++ b/6.0-nordb/test/integrated-tls.bats
@@ -1,1 +1,0 @@
-../../test/shared/integrated-tls.bats

--- a/6.0/test/acl-tls.bats
+++ b/6.0/test/acl-tls.bats
@@ -1,0 +1,1 @@
+../../test/shared/acl-tls.bats

--- a/6.0/test/integrated-tls.bats
+++ b/6.0/test/integrated-tls.bats
@@ -1,1 +1,0 @@
-../../test/shared/integrated-tls.bats

--- a/7.0-aof/test/acl-tls.bats
+++ b/7.0-aof/test/acl-tls.bats
@@ -1,0 +1,1 @@
+../../test/shared/acl-tls.bats

--- a/7.0-aof/test/integrated-tls.bats
+++ b/7.0-aof/test/integrated-tls.bats
@@ -1,1 +1,0 @@
-../../test/shared/integrated-tls.bats

--- a/7.0-nordb/test/acl-tls.bats
+++ b/7.0-nordb/test/acl-tls.bats
@@ -1,0 +1,1 @@
+../../test/shared/acl-tls.bats

--- a/7.0-nordb/test/integrated-tls.bats
+++ b/7.0-nordb/test/integrated-tls.bats
@@ -1,1 +1,0 @@
-../../test/shared/integrated-tls.bats

--- a/7.0/test/acl-tls.bats
+++ b/7.0/test/acl-tls.bats
@@ -1,0 +1,1 @@
+../../test/shared/acl-tls.bats

--- a/7.0/test/integrated-tls.bats
+++ b/7.0/test/integrated-tls.bats
@@ -1,1 +1,0 @@
-../../test/shared/integrated-tls.bats

--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -5,7 +5,7 @@ RUN addgroup "$REDIS_USER"
 RUN adduser -S "$REDIS_USER" -G "$REDIS_USER"
 
 <% if ENV.fetch('REDIS_VERSION').to_f >= 6.0 %>
-ENV INTEGRATED_TLS=true
+ENV VERSION_GTE_6=true
 RUN apk-install ca-certificates sudo
 <% else %>
 RUN apk-install supervisor ca-certificates

--- a/bin/redis-wrapper
+++ b/bin/redis-wrapper
@@ -17,4 +17,5 @@ exec redis-server \
   "$config_file" \
   --port "$REDIS_PORT" \
   --dir "$DATA_DIRECTORY" \
-  $(cat "$ARGUMENT_FILE")
+  $(cat "$ARGUMENT_FILE") \
+  $(cat "$RUNTIME_ARGUMENT_FILE")

--- a/bin/run-database.sh
+++ b/bin/run-database.sh
@@ -243,8 +243,8 @@ elif [[ "$1" == "--initialize-from" ]]; then
   shift
 
   # Always prefer connecting over SSL if that URL was provided.
-  for source_url in "$@"; do
-    parse_url "$source_url"
+  for url in "$@"; do
+    parse_url "$url"
     if [[ "$protocol" = "rediss://" ]]; then
       break
     fi
@@ -293,8 +293,8 @@ elif [[ "$1" == "--initialize-from" ]]; then
       REPL_PASS="${REPLICATION_PASSPHRASE:-"$(pwgen -s 32)"}"
 
       # Replica permissions https://redis.io/docs/manual/security/acl/#acl-rules-for-sentinel-and-replicas
-      start_redis_cli "$source_url" ACL SETUSER "$REPL_USER" on ">${REPL_PASS}" +psync +replconf +ping
-      start_redis_cli "$source_url" ACL SAVE
+      start_redis_cli "$url" ACL SETUSER "$REPL_USER" on ">${REPL_PASS}" +psync +replconf +ping
+      start_redis_cli "$url" ACL SAVE
 
       echo "--masteruser ${REPL_USER}" >> "$ARGUMENT_FILE"
       echo "--masterauth ${REPL_PASS}" >> "$ARGUMENT_FILE"

--- a/bin/run-database.sh
+++ b/bin/run-database.sh
@@ -6,13 +6,34 @@ set -o nounset
 . /usr/bin/utilities.sh
 
 export ARGUMENT_FILE="${CONFIG_DIRECTORY}/arguments"
+export RUNTIME_ARGUMENT_FILE="$(mktemp)"
 export CONFIG_EXTRA_FILE="${CONFIG_DIRECTORY}/redis.extra.conf"
+export ACL_DIRECTORY="${CONFIG_DIRECTORY}/acls"
+export ACL_FILE="${ACL_DIRECTORY}/users.acl"
+CA_CERT_FILE="/usr/local/share/ca-certificates/custom_ca.crt"
 DUMP_FILENAME="/tmp/dump.rdb"
 
 # This port is an arbitrary constant, and must point to the master we'll be
 # connecting to.
 MASTER_FORWARD_PORT=8765
 MASTER_FORWARD_CONF="${DATA_DIRECTORY}/master-tunnel.conf"
+
+# Redis 6 introduced user management
+if [[ -n "${VERSION_GTE_6:-}" ]]; then
+  : ${USERNAME:=aptible}
+else
+  USERNAME=''
+fi
+
+save_ca_certificate() {
+  if [[ -z "${CA_CERTIFICATE:-}" ]] || [[ -e "$CA_CERT_FILE" ]]; then
+    # Nothing to do!
+    return
+  fi
+
+  echo "$CA_CERTIFICATE" > "$CA_CERT_FILE"
+  update-ca-certificates
+}
 
 ensure_ssl_material() {
   if [[ -n "${SSL_CERTIFICATE:-}" ]] && [[ -n "${SSL_KEY:-}" ]]; then
@@ -81,6 +102,7 @@ create_ephemeral_tunnel() {
 start_redis_cli() {
   parse_url "$1"
   shift
+  save_ca_certificate
 
   # shellcheck disable=SC2154
   if [[ "$protocol" = "redis://" ]]; then
@@ -88,17 +110,22 @@ start_redis_cli() {
       port="$REDIS_PORT"
     fi
 
-    # shellcheck disable=SC2154
-    redis-cli -h "$host" -p "$port" -a "$password" "$@"
+    if [[ -n "${VERSION_GTE_6:-}" ]]; then
+      # shellcheck disable=SC2154
+      redis-cli -h "$host" -p "$port" --user "$user" --pass "$password" "$@"
+    else
+      # shellcheck disable=SC2154
+      redis-cli -h "$host" -p "$port" -a "$password" "$@"
+    fi
 
   elif [[ "$protocol" = "rediss://" ]]; then
     if [[ -z "$port" ]]; then
       port="$SSL_PORT"
     fi
 
-    if [[ -n "${INTEGRATED_TLS:-}" ]]; then
+    if [[ -n "${VERSION_GTE_6:-}" ]]; then
       # shellcheck disable=SC2154
-      redis-cli -h "$host" -p "$port" -a "$password" --tls "$@"
+      redis-cli -h "$host" -p "$port" --user "$user" --pass "$password" --tls "$@"
     else
       stunnel_dir="$(create_ephemeral_tunnel "$host" "$port")"
       redis-cli -h "127.0.1" -p "$(cat "${stunnel_dir}/port")" -a "$password" "$@"
@@ -113,8 +140,9 @@ start_redis_cli() {
 
 start_server() {
   ensure_ssl_material
+  save_ca_certificate
 
-  if [[ -n "${INTEGRATED_TLS:-}" ]]; then
+  if [[ -n "${VERSION_GTE_6:-}" ]]; then
     TLS_CERT_FILE="$(mktemp)"
     TLS_KEY_FILE="$(mktemp)"
 
@@ -156,20 +184,20 @@ EOF
   # Finally, we force-chown the data directory and its contents. There won't be many
   # files there so this isn't expensive, and it's needed because we used to run Redis
   # as root but no longer do.
-  chown -R "${REDIS_USER}:${REDIS_USER}" "$DATA_DIRECTORY"
+  chown -R "${REDIS_USER}:${REDIS_USER}" "$DATA_DIRECTORY" "$RUNTIME_ARGUMENT_FILE"
 
   touch "$ARGUMENT_FILE" # don't crash and burn if initialize wasn't called.
 
   if [[ -n "${MAX_MEMORY:-}" ]]; then
-    echo "--maxmemory-policy allkeys-lru" >> "$ARGUMENT_FILE"
-    echo "--maxmemory ${MAX_MEMORY}" >> "$ARGUMENT_FILE"
+    echo "--maxmemory-policy allkeys-lru" >> "$RUNTIME_ARGUMENT_FILE"
+    echo "--maxmemory ${MAX_MEMORY}" >> "$RUNTIME_ARGUMENT_FILE"
   fi
 
-  if [[ -n "${INTEGRATED_TLS:-}" ]]; then
-    echo "--tls-port ${SSL_PORT}" >> "$ARGUMENT_FILE"
-    echo "--tls-cert-file ${TLS_CERT_FILE}" >> "$ARGUMENT_FILE"
-    echo "--tls-key-file ${TLS_KEY_FILE}" >> "$ARGUMENT_FILE"
-    echo "--tls-auth-clients no" >> "$ARGUMENT_FILE"
+  if [[ -n "${VERSION_GTE_6:-}" ]]; then
+    echo "--tls-port ${SSL_PORT}" >> "$RUNTIME_ARGUMENT_FILE"
+    echo "--tls-cert-file ${TLS_CERT_FILE}" >> "$RUNTIME_ARGUMENT_FILE"
+    echo "--tls-key-file ${TLS_KEY_FILE}" >> "$RUNTIME_ARGUMENT_FILE"
+    echo "--tls-auth-clients no" >> "$RUNTIME_ARGUMENT_FILE"
 
     exec sudo -E -u "$REDIS_USER" redis-wrapper
   else
@@ -177,14 +205,23 @@ EOF
   fi
 }
 
+create_user() {
+  # Create an ACL file to store users in and create the initial user
+  mkdir -p "$ACL_DIRECTORY"
+  echo "user ${USERNAME} on >${PASSPHRASE} ~* +@all" > "$ACL_FILE"
+  echo "user default on >${PASSPHRASE} ~* +@all" >> "$ACL_FILE"
+  echo "--aclfile ${ACL_FILE}" >> "$ARGUMENT_FILE"
+  # The aclfile must be in a directory owned by the $REDIS_USER in order for
+  # ACL SAVE to work as this command creates a temporary file in the same directory
+  chown -R "${REDIS_USER}:${REDIS_USER}" "$ACL_DIRECTORY"
+}
 
 if [[ "$#" -eq 0 ]]; then
   start_server
 
 elif [[ "$1" == "--initialize" ]]; then
-  echo "--requirepass $PASSPHRASE" > "$ARGUMENT_FILE"
-
   touch "$CONFIG_EXTRA_FILE"
+  touch "$ARGUMENT_FILE"
 
   if [[ -n "${REDIS_NORDB:-}" ]]; then
     echo 'appendonly no' >> "$CONFIG_EXTRA_FILE"
@@ -195,13 +232,19 @@ elif [[ "$1" == "--initialize" ]]; then
     echo 'appendonly yes' >> "$CONFIG_EXTRA_FILE"
   fi
 
+  if [[ -n "${VERSION_GTE_6:-}" ]]; then
+    create_user
+  else
+    echo "--requirepass ${PASSPHRASE}" > "$ARGUMENT_FILE"
+  fi
+
 elif [[ "$1" == "--initialize-from" ]]; then
   [ -z "$2" ] && echo "docker run -i aptible/redis --initialize-from redis://... rediss://..." && exit
   shift
 
   # Always prefer connecting over SSL if that URL was provided.
-  for url in "$@"; do
-    parse_url "$url"
+  for source_url in "$@"; do
+    parse_url "$source_url"
     if [[ "$protocol" = "rediss://" ]]; then
       break
     fi
@@ -213,12 +256,11 @@ elif [[ "$1" == "--initialize-from" ]]; then
     fi
 
   elif [[ "$protocol" = "rediss://" ]]; then
-    if [[ -n "${INTEGRATED_TLS:-}" ]]; then
+    if [[ -n "${VERSION_GTE_6:-}" ]]; then
       if [[ -z "$port" ]]; then
         port="$SSL_PORT"
       fi
 
-      tls_replication='yes'
     else
       create_tunnel_configuration redis-master \
         "127.0.0.1" "$MASTER_FORWARD_PORT" \
@@ -233,12 +275,36 @@ elif [[ "$1" == "--initialize-from" ]]; then
   fi
 
   {
-    echo "--requirepass $password" > "$ARGUMENT_FILE"
-    echo "--slaveof $host ${port}" >> "$ARGUMENT_FILE"
-    echo "--masterauth $password" >> "$ARGUMENT_FILE"
-    if [[ -n "${tls_replication:-}" ]]; then
-      echo '--tls-replication yes' >> "$ARGUMENT_FILE"
-      echo "--tls-ca-cert-dir ${SSL_CERTS_DIRECTORY}" >> "$ARGUMENT_FILE"
+    echo "--slaveof ${host} ${port}" > "$ARGUMENT_FILE"
+    if [[ -n "${VERSION_GTE_6:-}" ]]; then
+      create_user
+
+      if [[ -n "${REPLCIATION_USERNAME:-}" ]]; then
+        REPL_USER="$REPLICATION_USERNAME"
+      else
+        if [[ -n "${APTIBLE_DATABASE_HREF:-}" ]]; then
+          DATABASE_ID="${APTIBLE_DATABASE_HREF##*/}"
+          REPL_USER="repl_${DATABASE_ID}"
+        else
+          REPL_USER="repl_$(pwgen -s 20 | tr '[:upper:]' '[:lower:]')_$(date +%s)"
+        fi
+      fi
+
+      REPL_PASS="${REPLICATION_PASSPHRASE:-"$(pwgen -s 32)"}"
+
+      # Replica permissions https://redis.io/docs/manual/security/acl/#acl-rules-for-sentinel-and-replicas
+      start_redis_cli "$source_url" ACL SETUSER "$REPL_USER" on ">${REPL_PASS}" +psync +replconf +ping
+      start_redis_cli "$source_url" ACL SAVE
+
+      echo "--masteruser ${REPL_USER}" >> "$ARGUMENT_FILE"
+      echo "--masterauth ${REPL_PASS}" >> "$ARGUMENT_FILE"
+      if [[ "$protocol" = "rediss://" ]]; then
+        echo '--tls-replication yes' >> "$ARGUMENT_FILE"
+        echo "--tls-ca-cert-dir ${SSL_CERTS_DIRECTORY}" >> "$ARGUMENT_FILE"
+      fi
+    else
+      echo "--masterauth ${password}" >> "$ARGUMENT_FILE"
+      echo "--requirepass ${password}" >> "$ARGUMENT_FILE"
     fi
   }
 
@@ -295,12 +361,12 @@ elif [[ "$1" == "--connection-url" ]]; then
     {
       "type": "redis",
       "default": true,
-      "connection_url": "${REDIS_PROTOCOL}://:${PASSPHRASE}@${EXPOSE_HOST}:${!REDIS_EXPOSE_PORT_PTR}"
+      "connection_url": "${REDIS_PROTOCOL}://${USERNAME}:${PASSPHRASE}@${EXPOSE_HOST}:${!REDIS_EXPOSE_PORT_PTR}"
     },
     {
       "type": "redis+ssl",
       "default": false,
-      "connection_url": "${SSL_PROTOCOL}://:${PASSPHRASE}@${EXPOSE_HOST}:${!SSL_EXPOSE_PORT_PTR}"
+      "connection_url": "${SSL_PROTOCOL}://${USERNAME}:${PASSPHRASE}@${EXPOSE_HOST}:${!SSL_EXPOSE_PORT_PTR}"
     }
   ]
 }

--- a/bin/utilities.sh
+++ b/bin/utilities.sh
@@ -5,7 +5,7 @@ parse_url()
   # cf http://stackoverflow.com/a/17287984
   protocol="$(echo "$1" | grep :// | sed -e's,^\(.*://\).*,\1,g')"
   # remove the protocol
-  url=$(echo $1 | sed -e s,$protocol,,g)
+  local url=$(echo $1 | sed -e s,$protocol,,g)
   # extract the user and password (if any)
   user_and_password="$(echo $url | grep @ | cut -d@ -f1)"
   password="$(echo $user_and_password | grep : | cut -d: -f2)"

--- a/test-replication.sh
+++ b/test-replication.sh
@@ -3,27 +3,29 @@ set -o errexit
 set -o nounset
 
 IMG="$1"
-CA_CERT_FILE='/tmp/test/ssl/ca.pem'
+SSL_KEY="$(cat test/ssl/server-key.pem)"
+SSL_CERT="$(cat test/ssl/server-cert.pem)"
+CA_CERT="$(cat test/ssl/ca.pem)"
 
 PROTOCOL="redis"
 PORT_VARIABLE="REDIS_PORT"
-
-CLIENT_OPTS=()
-DUMP_RESTORE_OPTS=""
 
 if [[ "$#" -eq 2 ]]; then
   if [[ "$2" = "ssl" ]]; then
     PROTOCOL="rediss"
     PORT_VARIABLE="SSL_PORT"
-
-    if [[ "$(echo "$REDIS_VERSION" | cut -f1 -d.)" -ge '6' ]]; then
-      CLIENT_OPTS=(--cacert "$CA_CERT_FILE")
-      DUMP_RESTORE_OPTS="--cacert '$CA_CERT_FILE'"
-    fi
   else
     echo "Unknown argument: $2"
     exit 1
   fi
+fi
+
+if [[ "$(echo "$REDIS_VERSION" | cut -f1 -d.)" -ge '6' ]]; then
+  USERNAME='testuser'
+  OPTS=(-e CA_CERTIFICATE="$CA_CERT")
+else
+  USERNAME=''
+  OPTS=(-e DANGER_DISABLE_CERT_VALIDATION=1)
 fi
 
 MASTER_CONTAINER="redis-master"
@@ -37,8 +39,6 @@ CLONE_DATA_CONTAINER="${CLONE_CONTAINER}-data"
 FIFO_CONTAINER="redis-fifo"
 FIFO_EXPORT="redis-fifo-out"
 FIFO_IMPORT="redis-fifo-in"
-
-OPTS=(-e DANGER_DISABLE_CERT_VALIDATION=1)
 
 function cleanup {
   docker rm -f \
@@ -54,7 +54,7 @@ cleanup
 
 PASSPHRASE=testpass
 
-echo "Running replication test with protocol $PROTOCOL and port $PORT_VARIABLE"
+echo "Running replication test with protocol ${PROTOCOL} and port ${PORT_VARIABLE}"
 
 
 echo "Initializing data containers"
@@ -68,27 +68,28 @@ docker run --name "$FIFO_CONTAINER" --entrypoint /bin/sh  "$IMG" -c "mkfifo /var
 echo "Initializing master"
 
 docker run -it --rm \
-  -e PASSPHRASE="${PASSPHRASE}" \
+  -e PASSPHRASE="$PASSPHRASE" \
+  -e USERNAME="$USERNAME" \
   --volumes-from "$MASTER_DATA_CONTAINER" \
   "${OPTS[@]}" "$IMG" --initialize
 
 MASTER_PORT=63791
 docker run -d --name="${MASTER_CONTAINER}" \
   -e "${PORT_VARIABLE}=$MASTER_PORT" \
-  -e SSL_KEY="$(cat test/ssl/server-key.pem)" \
-  -e SSL_CERTIFICATE="$(cat test/ssl/server-cert.pem)" \
+  -e SSL_KEY="$SSL_KEY" \
+  -e SSL_CERTIFICATE="$SSL_CERT" \
   --volumes-from "$MASTER_DATA_CONTAINER" \
   "${IMG}"
 
 MASTER_IP="$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' "$MASTER_CONTAINER")"
-MASTER_URL="$PROTOCOL://:$PASSPHRASE@$MASTER_IP:$MASTER_PORT"
+MASTER_URL="${PROTOCOL}://${USERNAME}:${PASSPHRASE}@${MASTER_IP}:${MASTER_PORT}"
 # Empty arrays are considered unset by some shells.
 # "${ARR[@]+"${ARR[@]}"}" prevents the script from exiting due to nounset.
-until docker run --rm "${OPTS[@]}" "$IMG" --client "$MASTER_URL" "${CLIENT_OPTS[@]+"${CLIENT_OPTS[@]}"}" INFO >/dev/null; do sleep 0.5; done
+until docker run --rm "${OPTS[@]}" "$IMG" --client "$MASTER_URL" INFO >/dev/null; do sleep 0.5; done
 
 echo "Adding test data"
 
-docker run -it --rm "${OPTS[@]}" "$IMG" --client "$MASTER_URL" "${CLIENT_OPTS[@]+"${CLIENT_OPTS[@]}"}" SET test_before TEST_DATA
+docker run -it --rm "${OPTS[@]}" "$IMG" --client "$MASTER_URL" SET test_before TEST_DATA
 
 echo "Initializing slave"
 
@@ -103,27 +104,31 @@ else
 fi
 
 docker run -it --rm \
+  -e PASSPHRASE="$PASSPHRASE" \
+  -e USERNAME="$USERNAME" \
+  -e CA_CERTIFICATE="$CA_CERT" \
   --volumes-from "$SLAVE_DATA_CONTAINER" \
   "${OPTS[@]}" "$IMG" --initialize-from "${INITIALIZE_FROM_ARGS[@]}"
 
 SLAVE_PORT=63792
 docker run -d --name "$SLAVE_CONTAINER" \
   -e "${PORT_VARIABLE}=$SLAVE_PORT" \
-  -e SSL_KEY="$(cat test/ssl/server-key.pem)" \
-  -e SSL_CERTIFICATE="$(cat test/ssl/server-cert.pem)" \
+  -e SSL_KEY="$SSL_KEY" \
+  -e SSL_CERTIFICATE="$SSL_CERT" \
+  -e CA_CERTIFICATE="$CA_CERT" \
   --volumes-from "$SLAVE_DATA_CONTAINER" \
   "${OPTS[@]}" "$IMG"
 
-docker exec "$SLAVE_CONTAINER" cp "$CA_CERT_FILE" /usr/local/share/ca-certificates/test_ca.crt
-docker exec "$SLAVE_CONTAINER" update-ca-certificates
+#docker exec "$SLAVE_CONTAINER" cp "$CA_CERT_FILE" /usr/local/share/ca-certificates/test_ca.crt
+#docker exec "$SLAVE_CONTAINER" update-ca-certificates
 
 SLAVE_IP="$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' "$SLAVE_CONTAINER")"
-SLAVE_URL="$PROTOCOL://:$PASSPHRASE@$SLAVE_IP:$SLAVE_PORT"
-until docker run --rm "${OPTS[@]}" "$IMG" --client "$SLAVE_URL" "${CLIENT_OPTS[@]+"${CLIENT_OPTS[@]}"}" INFO >/dev/null; do sleep 0.5; done
+SLAVE_URL="${PROTOCOL}://${USERNAME}:${PASSPHRASE}@${SLAVE_IP}:${SLAVE_PORT}"
+until docker run --rm "${OPTS[@]}" "$IMG" --client "$SLAVE_URL" INFO >/dev/null; do sleep 0.5; done
 
 echo "Adding test data"
 
-docker run -it --rm "${OPTS[@]}" "$IMG" --client "$MASTER_URL" "${CLIENT_OPTS[@]+"${CLIENT_OPTS[@]}"}" SET test_after TEST_DATA
+docker run -it --rm "${OPTS[@]}" "$IMG" --client "$MASTER_URL" SET test_after TEST_DATA
 
 echo "Checking test data"
 
@@ -132,7 +137,7 @@ RETRY_TIMES=30
 
 wait_for_key() {
   for i in $(seq "$RETRY_TIMES"); do
-    docker run -it --rm "${OPTS[@]}" "$IMG" --client "$SLAVE_URL" "${CLIENT_OPTS[@]+"${CLIENT_OPTS[@]}"}" GET "$1" | grep "$2" && return 0
+    docker run -it --rm "${OPTS[@]}" "$IMG" --client "$SLAVE_URL" GET "$1" | grep "$2" && return 0
     sleep 0.5
   done
 
@@ -154,25 +159,26 @@ fi
 echo "Creating empty clone"
 
 docker run -it --rm \
-  -e PASSPHRASE="${PASSPHRASE}" \
+  -e PASSPHRASE="$PASSPHRASE" \
+  -e USERNAME="$USERNAME" \
   --volumes-from "$CLONE_DATA_CONTAINER" \
   "${OPTS[@]}" "$IMG" --initialize
 
 CLONE_PORT=63793
 docker run -d --name="${CLONE_CONTAINER}" \
   -e "${PORT_VARIABLE}=$CLONE_PORT" \
-  -e SSL_KEY="$(cat test/ssl/server-key.pem)" \
-  -e SSL_CERTIFICATE="$(cat test/ssl/server-cert.pem)" \
+  -e SSL_KEY="$SSL_KEY" \
+  -e SSL_CERTIFICATE="$SSL_CERT" \
   --volumes-from "$CLONE_DATA_CONTAINER" \
   "${IMG}"
 
 CLONE_IP="$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' "$CLONE_CONTAINER")"
-CLONE_URL="$PROTOCOL://:$PASSPHRASE@$CLONE_IP:$CLONE_PORT"
-until docker run --rm "${OPTS[@]}" "$IMG" --client "$CLONE_URL" "${CLIENT_OPTS[@]+"${CLIENT_OPTS[@]}"}" INFO >/dev/null; do sleep 0.5; done
+CLONE_URL="${PROTOCOL}://${USERNAME}:${PASSPHRASE}@${CLONE_IP}:${CLONE_PORT}"
+until docker run --rm "${OPTS[@]}" "$IMG" --client "$CLONE_URL" INFO >/dev/null; do sleep 0.5; done
 
 
 echo "Checking master has no data"
-docker run -it --rm "${OPTS[@]}" "$IMG" --client "$CLONE_URL" "${CLIENT_OPTS[@]+"${CLIENT_OPTS[@]}"}" --cacert GET test_after | grep "TEST_DATA" && false
+docker run -it --rm "${OPTS[@]}" "$IMG" --client "$CLONE_URL" --cacert GET test_after | grep "TEST_DATA" && false
 
 
 echo "Cloning master"
@@ -180,14 +186,14 @@ echo "Cloning master"
 docker run --name "$FIFO_EXPORT" -d \
   --volumes-from "${FIFO_CONTAINER}" \
   --entrypoint "/bin/sh" \
-  "${OPTS[@]}" "$IMG" "-c" "ln -s '/var/db/fifo' '/dump-output' && run-database.sh --dump '$MASTER_URL' $DUMP_RESTORE_OPTS"
+  "${OPTS[@]}" "$IMG" "-c" "ln -s '/var/db/fifo' '/dump-output' && run-database.sh --dump '$MASTER_URL'"
 
 docker run --name "$FIFO_IMPORT" -it \
   --volumes-from "${FIFO_CONTAINER}" \
   --entrypoint "/bin/sh" \
-  "${OPTS[@]}" "$IMG" "-c" "ln -s '/var/db/fifo' '/restore-input' && run-database.sh --restore '$CLONE_URL' $DUMP_RESTORE_OPTS"
+  "${OPTS[@]}" "$IMG" "-c" "ln -s '/var/db/fifo' '/restore-input' && run-database.sh --restore '$CLONE_URL'"
 
-docker run -it --rm "${OPTS[@]}" "$IMG" --client "$CLONE_URL" "${CLIENT_OPTS[@]+"${CLIENT_OPTS[@]}"}" GET test_after | grep "TEST_DATA"
+docker run -it --rm "${OPTS[@]}" "$IMG" --client "$CLONE_URL" GET test_after | grep "TEST_DATA"
 
 
 echo "Clone test OK!"

--- a/test/redis.bats
+++ b/test/redis.bats
@@ -2,9 +2,8 @@
 
 source '/tmp/test/test_helper.sh'
 
-CLIENT_OPTS=()
-if [ -n "$INTEGRATED_TLS" ]; then
-  CLIENT_OPTS=(--cacert "${TEST_ROOT}/ssl/ca.pem")
+if [ -n "$VERSION_GTE_6" ]; then
+  export CA_CERTIFICATE="$(cat "${TEST_ROOT}/ssl/ca.pem")"
 fi
 
 setup() {
@@ -37,8 +36,8 @@ teardown() {
 @test "It should support SSL connections" {
   initialize_redis
   start_redis
-  run-database.sh --client "$SSL_DATABASE_URL" "${CLIENT_OPTS[@]}" SET test_key test_value
-  run run-database.sh --client "$SSL_DATABASE_URL_FULL" "${CLIENT_OPTS[@]}" GET test_key
+  run-database.sh --client "$SSL_DATABASE_URL" SET test_key test_value
+  run run-database.sh --client "$SSL_DATABASE_URL_FULL" GET test_key
   [ "$status" -eq "0" ]
   [[ "$output" =~ "test_value" ]]
 }
@@ -47,7 +46,7 @@ teardown() {
   initialize_redis
   start_redis
   run-database.sh --client "$REDIS_DATABASE_URL" SET test_key test_value
-  run run-database.sh --client "$SSL_DATABASE_URL" "${CLIENT_OPTS[@]}" GET test_key
+  run run-database.sh --client "$SSL_DATABASE_URL" GET test_key
   [ "$status" -eq "0" ]
   [[ "$output" =~ "test_value" ]]
 }
@@ -103,7 +102,7 @@ backup_restore_test() {
   # Load a key
   initialize_redis
   start_redis
-  backup_restore_test "$SSL_DATABASE_URL" "${CLIENT_OPTS[@]}"
+  backup_restore_test "$SSL_DATABASE_URL"
 }
 
 export_exposed_ports() {
@@ -144,7 +143,7 @@ export_exposed_ports() {
   popd
 
   [[ "$SSL_DATABASE_URL_FULL" = "$URL" ]]
-  run-database.sh --client "$URL" "${CLIENT_OPTS[@]}" INFO
+  run-database.sh --client "$URL" INFO
 }
 
 @test "It prints the persistent configuration changes on boot." {

--- a/test/shared/acl-tls.bats
+++ b/test/shared/acl-tls.bats
@@ -10,6 +10,24 @@ teardown() {
   do_teardown
 }
 
+@test "It allows ACLs to be saved" {
+  user='acl_user'
+  pass='acl_pass'
+
+  initialize_redis
+  start_redis
+
+  run-database.sh --client "$REDIS_DATABASE_URL" ACL SETUSER "$user" on ">${pass}" '+@all'
+  run-database.sh --client "$REDIS_DATABASE_URL" ACL SAVE
+
+  stop_redis
+  start_redis
+
+  run run-database.sh --client "$REDIS_DATABASE_URL" AUTH "$user" "$pass"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ 'OK' ]]
+}
+
 @test "It allows TLS1.2" {
   initialize_redis
   start_redis


### PR DESCRIPTION
- Create an `aptible` user by default
- Allow ACLs to be saved
- Updated `start_server` to write to a non-persisted file as writing to the `$ARGUMENTS_FILE` results in the file being appended to every time the container starts.
- Added the option to provide a `CA_CERTIFICATE` mainly to make testing easier.