### PR TITLE
Write to runtime arg file before changing owner

### DIFF
--- a/bin/run-database.sh
+++ b/bin/run-database.sh
@@ -184,7 +184,7 @@ EOF
   # Finally, we force-chown the data directory and its contents. There won't be many
   # files there so this isn't expensive, and it's needed because we used to run Redis
   # as root but no longer do.
-  chown -R "${REDIS_USER}:${REDIS_USER}" "$DATA_DIRECTORY" "$RUNTIME_ARGUMENT_FILE"
+  chown -R "${REDIS_USER}:${REDIS_USER}" "$DATA_DIRECTORY"
 
   touch "$ARGUMENT_FILE" # don't crash and burn if initialize wasn't called.
 
@@ -199,8 +199,10 @@ EOF
     echo "--tls-key-file ${TLS_KEY_FILE}" >> "$RUNTIME_ARGUMENT_FILE"
     echo "--tls-auth-clients no" >> "$RUNTIME_ARGUMENT_FILE"
 
+    chown "${REDIS_USER}:${REDIS_USER}" "$RUNTIME_ARGUMENT_FILE"
     exec sudo -E -u "$REDIS_USER" redis-wrapper
   else
+    chown "${REDIS_USER}:${REDIS_USER}" "$RUNTIME_ARGUMENT_FILE"
     exec supervisord -c "/etc/supervisord.conf"
   fi
 }


### PR DESCRIPTION
Tried creating a Redis DB and ran into the following error:

```
/usr/bin/run-database.sh: line 197: /tmp/tmp.d2dbq2Bn3N: Permission denied
```

I believe it's a result of changing the ownership of the runtime arg file before writing to it and it didn't show up in tests due to differences in [sysctl settings](https://unix.stackexchange.com/questions/691441/root-cannot-write-to-file-that-is-owned-by-regular-user) between our testing an production environments. Waiting to change ownership until after the file is written is a better practice regardless.